### PR TITLE
Add interactive TUI option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,5 @@ rayon = "1"
 clap = { version = "4", features = ["derive"] }
 dialoguer = "0.10"
 
-[dev-dependencies]tempfile = "3.15.0"
+[dev-dependencies]
+tempfile = "3.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,6 @@ chrono = "0.4.41"
 whoami = "1.6.0"
 rayon = "1"
 clap = { version = "4", features = ["derive"] }
+dialoguer = "0.10"
 
-[dev-dependencies]
-tempfile = "3.15.0"
+[dev-dependencies]tempfile = "3.15.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
-use clap::{Parser, ArgGroup};
+use clap::Parser;
+use dialoguer::{MultiSelect, Input};
 use log::{error, info};
 use chrono::Local;
 use duplicate_file_finder::{setup_logger, find_duplicates, find_duplicates_in_dirs, write_output};
@@ -11,27 +12,98 @@ const DEFAULT_REPORT_FILENAME: &str = "duplicate_file_report.txt";
 #[command(
     author,
     version = VERSION,
-    about = "Scans the specified directory recursively for duplicate files.",
-    group = ArgGroup::new("input").required(true).args(["directory", "directories"])
+    about = "Scans the specified directory recursively for duplicate files."
 )]
 struct Cli {
     /// Directory to scan for duplicates
-    #[arg(group = "input")]
     directory: Option<PathBuf>,
 
     /// One or more directories to scan for duplicates
-    #[arg(short = 'd', long = "directories", value_name = "DIR", num_args = 1.., group = "input")]
+    #[arg(short = 'd', long = "directories", value_name = "DIR", num_args = 1..)]
     directories: Option<Vec<PathBuf>>,
+
+    /// Launch interactive TUI
+    #[arg(long)]
+    gui: bool,
 
     /// Output file or directory for the report
     #[arg(short, long, value_name = "FILE")]
     output: Option<PathBuf>,
 }
 
+fn run_gui() {
+    let mut dirs: Vec<PathBuf> = Vec::new();
+    let entries: Vec<PathBuf> = std::fs::read_dir(".")
+        .unwrap()
+        .filter_map(|e| {
+            let p = e.ok()?.path();
+            if p.is_dir() { Some(p) } else { None }
+        })
+        .collect();
+
+    if entries.is_empty() {
+        println!("No directories found in current location");
+        return;
+    }
+
+    let options: Vec<String> = entries.iter().map(|p| p.display().to_string()).collect();
+    let selections = MultiSelect::new()
+        .with_prompt("Select directories to scan")
+        .items(&options)
+        .interact()
+        .unwrap();
+
+    if selections.is_empty() {
+        println!("No directories selected. Exiting.");
+        return;
+    }
+
+    for i in selections {
+        dirs.push(entries[i].clone());
+    }
+
+    let output: String = Input::new()
+        .with_prompt("Output file")
+        .default(String::from(DEFAULT_REPORT_FILENAME))
+        .interact_text()
+        .unwrap();
+
+    let mut output_file = PathBuf::from(output);
+    if output_file.is_dir() {
+        output_file = output_file.join(DEFAULT_REPORT_FILENAME);
+    }
+
+    let start_time = Local::now().format("%Y%m%d %H:%M:%S").to_string();
+
+    let duplicates = if dirs.len() == 1 {
+        find_duplicates(&dirs[0])
+    } else {
+        find_duplicates_in_dirs(&dirs)
+    };
+
+    if duplicates.is_empty() {
+        println!("No duplicate files found.");
+    } else if let Err(e) = write_output(duplicates, output_file.to_str().unwrap(), &start_time, &dirs) {
+        eprintln!("Error writing output: {}", e);
+    } else {
+        println!("Duplicate file report saved to {}", output_file.display());
+    }
+}
+
 fn main() {
     setup_logger().expect("Failed to initialize logger");
 
     let cli = Cli::parse();
+
+    if cli.gui {
+        run_gui();
+        return;
+    }
+
+    if cli.directory.is_none() && cli.directories.is_none() {
+        eprintln!("Error: no directory specified. Use <directory> or --directories, or --gui for interactive mode.");
+        std::process::exit(1);
+    }
 
     let dirs: Vec<PathBuf> = if let Some(multi) = cli.directories.clone() {
         multi


### PR DESCRIPTION
## Summary
- allow running the tool in an interactive terminal UI
- support selecting directories and output path within the TUI
- show progress and write the report like the CLI mode

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686dc16175488327bf4c43d027c177d5