### PR TITLE
Improve docs for public functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,18 +14,25 @@ use std::error::Error;
 use rayon::prelude::*;
 use std::sync::Arc;
 
-/// Initializes and configures logging for the application using the `fern` backend.
+/// Initializes logging for the library and command line tool.
 ///
-/// Logs are written to a file named `duplicate_finder.log` with timestamps and log levels.
-/// This function should be called before any logging takes place.
+/// The logger records messages to a file called `duplicate_finder.log` and
+/// formats each entry with a timestamp and log level. Call this once near the
+/// start of your program before emitting any log messages.
 ///
 /// # Errors
-/// Returns a `fern::InitError` if the logger fails to initialize.
+/// Returns a [`fern::InitError`] if the logger fails to initialize.
 ///
 /// # Example
 /// ```
-/// use duplicate_file_finder::{setup_logger};
-/// setup_logger().expect("Failed to initialize logger");
+/// use duplicate_file_finder::setup_logger;
+/// use log::info;
+///
+/// fn init() -> Result<(), fern::InitError> {
+///     setup_logger()?;
+///     info!("logging ready");
+///     Ok(())
+/// }
 /// ```
 #[must_use]
 pub fn setup_logger() -> Result<(), fern::InitError> {
@@ -47,16 +54,31 @@ pub fn setup_logger() -> Result<(), fern::InitError> {
 
 /// Recursively scans the provided directory for duplicate files.
 ///
-/// The process groups files by size, then by a quick hash, and finally by a full SHA-256 hash
-/// to identify true duplicates. Only files that match in size, quick hash, and full hash
-/// are considered duplicates.
+/// Files are grouped by size, then by a quick non-cryptographic hash and
+/// finally by a full SHA-256 hash. Only files matching at every stage are
+/// returned as duplicates.
 ///
 /// # Arguments
 /// * `dir` - The root path to scan for duplicate files.
 ///
 /// # Returns
-/// A `HashMap` where the key is the SHA-256 hash of the file contents and the value is a `Vec<PathBuf>` containing paths to files with identical content.
+/// A map from SHA‑256 hash to a list of files sharing that hash.
 ///
+/// # Example
+/// ```
+/// use duplicate_file_finder::find_duplicates;
+/// use std::io::Write;
+/// use tempfile::tempdir;
+///
+/// fn check() -> std::io::Result<()> {
+///     let dir = tempdir()?;
+///     std::fs::write(dir.path().join("a.txt"), b"same")?;
+///     std::fs::write(dir.path().join("b.txt"), b"same")?;
+///     let dupes = find_duplicates(dir.path());
+///     assert_eq!(dupes.values().next().unwrap().len(), 2);
+///     Ok(())
+/// }
+/// ```
 pub fn find_duplicates(dir: &Path) -> HashMap<String, Vec<PathBuf>> {
     find_duplicates_in_dirs(&[dir.to_path_buf()])
 }


### PR DESCRIPTION
## Summary
- improve documentation for `setup_logger` and `find_duplicates`
- provide compilable examples

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_686dc1eb8b088327904ad571e1586fc7