### PR TITLE
Add default current directory option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ cargo install duplicate_file_finder
 ### Command Line
 
 ```bash
+duplicate_file_finder [--output <file_or_directory>]
 duplicate_file_finder <directory> [--output <file_or_directory>]
 duplicate_file_finder --directories <dir1> <dir2> ... [--output <file_or_directory>]
 ```
@@ -51,6 +52,8 @@ duplicate_file_finder ~/Documents --output reports/
 ```
 
 This scans `~/Documents` and writes a human-readable report to `reports/duplicate_file_report.txt`.
+
+Running `duplicate_file_finder` with no arguments scans the directory it is executed from and saves `duplicate_file_report.txt` in that same directory.
 
 ### Options
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
 #![warn(clippy::pedantic)]
 
-use std::path::PathBuf;
-use clap::{Parser, ArgGroup};
-use log::{error, info};
 use chrono::Local;
-use duplicate_file_finder::{setup_logger, find_duplicates, find_duplicates_in_dirs, write_output};
+use clap::{ArgGroup, Parser};
+use duplicate_file_finder::{find_duplicates, find_duplicates_in_dirs, setup_logger, write_output};
+use log::{error, info};
+use std::path::PathBuf;
 
 const VERSION: &str = "0.1.4";
 const DEFAULT_REPORT_FILENAME: &str = "duplicate_file_report.txt";
@@ -14,7 +14,7 @@ const DEFAULT_REPORT_FILENAME: &str = "duplicate_file_report.txt";
     author,
     version = VERSION,
     about = "Scans the specified directory recursively for duplicate files.",
-    group = ArgGroup::new("input").required(true).args(["directory", "directories"])
+    group = ArgGroup::new("input").args(["directory", "directories"])
 )]
 struct Cli {
     /// Directory to scan for duplicates
@@ -37,8 +37,10 @@ fn main() {
 
     let dirs: Vec<PathBuf> = if let Some(multi) = cli.directories.clone() {
         multi
+    } else if let Some(dir) = cli.directory.clone() {
+        vec![dir]
     } else {
-        vec![cli.directory.clone().expect("a directory path is required")] 
+        vec![std::env::current_dir().expect("cannot determine current directory")]
     };
 
     let mut output_file = cli
@@ -63,7 +65,10 @@ fn main() {
         info!("Starting duplicate file detection in {}", dirs[0].display());
     } else {
         println!("Scanning {} directories", dirs.len());
-        info!("Starting duplicate file detection across {} directories", dirs.len());
+        info!(
+            "Starting duplicate file detection across {} directories",
+            dirs.len()
+        );
     }
     println!("Output will be saved to: {}", output_file.display());
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,13 +1,13 @@
+use std::fs;
 use std::path::Path;
 use std::process::Command;
-use std::fs;
 use tempfile::tempdir;
 use walkdir::WalkDir;
 
 fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
     for entry in WalkDir::new(src) {
         let entry = entry?;
-    let rel = entry.path().strip_prefix(src).expect("strip_prefix failed");
+        let rel = entry.path().strip_prefix(src).expect("strip_prefix failed");
         let full_destination = dst.join(rel);
         if entry.file_type().is_dir() {
             fs::create_dir_all(&full_destination)?;
@@ -43,6 +43,18 @@ fn default_output_file_generated() {
     assert!(report.exists());
     let content = fs::read_to_string(report).expect("read report");
     assert!(content.contains("Duplicate File Finder Report"));
+}
+
+#[test]
+fn no_arguments_scans_current_directory() {
+    let tmp = tempdir().expect("create temp dir");
+    copy_dir_recursive(Path::new("resources"), tmp.path()).expect("copy resources");
+
+    let output = run_with_args(tmp.path(), &[]);
+    assert!(output.status.success());
+
+    let report = tmp.path().join("duplicate_file_report.txt");
+    assert!(report.exists());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- allow running with no arguments
- save report to current directory when no args supplied
- document new behaviour in README
- test running with no arguments

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6871883523548327be093e9ea2190019