### PR TITLE
Reference cargo version & prepare release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "duplicate_file_finder"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 authors = ["Andrew Sims andrew,simsd.@gmail.com"]
 description = "Finds duplicate files."

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use duplicate_file_finder::{find_duplicates, find_duplicates_in_dirs, setup_logg
 use log::{error, info};
 use std::path::PathBuf;
 
-const VERSION: &str = "0.1.4";
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 const DEFAULT_REPORT_FILENAME: &str = "duplicate_file_report.txt";
 
 #[derive(Parser)]


### PR DESCRIPTION
## Summary
- use `CARGO_PKG_VERSION` in `main.rs`
- bump crate version to 0.1.5
- tag v0.1.5 for release

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68718fb3140c8327b4a7316f1c2d10f4